### PR TITLE
style: fix tbody>tr height when displaying one grade

### DIFF
--- a/server/public/stylesheets/styles.css
+++ b/server/public/stylesheets/styles.css
@@ -46,6 +46,7 @@ html {
 }
 .gradetable {
   width: 100%;
+  align-self: flex-start;
 }
 table {
   width: 100%;


### PR DESCRIPTION
- set `align-self: flex-start` to `.gradetable`