### PR TITLE
style: fix height for no student grade message

### DIFF
--- a/server/public/stylesheets/styles.css
+++ b/server/public/stylesheets/styles.css
@@ -43,10 +43,14 @@ html {
 .gradetableContainer {
   display: flex;
   justify-content: center;
+  min-width: 340px;
+}
+.gradetableContainer table,
+.gradetable {
+  align-self: flex-start;
 }
 .gradetable {
   width: 100%;
-  align-self: flex-start;
 }
 table {
   width: 100%;


### PR DESCRIPTION
- set `.align-self: flex-start` to `.gradetableContainer table`
- set min-width for `.gradetableContainer`